### PR TITLE
Improve queue discovery

### DIFF
--- a/src/bull/bull-queues.service.ts
+++ b/src/bull/bull-queues.service.ts
@@ -376,7 +376,8 @@ export class BullQueuesService implements OnModuleInit, OnModuleDestroy {
           await Promise.all([
             // this.findAndPopulateQueues(`${queuePrefix}:*:stalled-check`),
             //this.findAndPopulateQueues(`${queuePrefix}:*:id`),
-            this.findAndPopulateQueues(`${queuePrefix}:*:meta`),
+            //this.findAndPopulateQueues(`${queuePrefix}:*:meta`),
+            this.findAndPopulateQueues(`${queuePrefix}:*:*`),
           ])
         ).flat();
       }


### PR DESCRIPTION
This PR is related to this issue: https://github.com/ejhayes/bull-monitor/issues/130

In our environment we are using the integration nestjs bull and in our redis we don't have `bull:*:meta` keys, so the idea is to be able to discover queues without the need to have these keys.
Maybe I 'm missing something about the meta keys, I'm beginner with bull system.