### PR TITLE
HOTFIX: TypeError Cannot read properties of undefined (reading 'name')

### DIFF
--- a/src/bull/bullmq-metrics.factory.ts
+++ b/src/bull/bullmq-metrics.factory.ts
@@ -204,7 +204,7 @@ export class BullMQMetricsFactory {
     queueEvents.on('stalled', async (event) => {
       const job = await queue.getJob(event.jobId);
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         ...labels,
       };
       this.jobs_stalled.inc(jobLabels, 1);
@@ -212,7 +212,7 @@ export class BullMQMetricsFactory {
     queueEvents.on('active', async (event) => {
       const job = await queue.getJob(event.jobId);
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         ...labels,
       };
       this.jobs_active.inc(jobLabels, 1);
@@ -220,7 +220,7 @@ export class BullMQMetricsFactory {
     queueEvents.on('waiting', async (event) => {
       const job = await queue.getJob(event.jobId);
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         ...labels,
       };
       this.jobs_waiting.inc(jobLabels, 1);
@@ -231,7 +231,7 @@ export class BullMQMetricsFactory {
         /^(?<errorType>[^:]+):/,
       )?.groups?.errorType;
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         [LABEL_NAMES.ERROR_TYPE]: errorType,
         ...labels,
       };
@@ -241,7 +241,7 @@ export class BullMQMetricsFactory {
     queueEvents.on('delayed', async (event) => {
       const job = await queue.getJob(event.jobId);
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         ...labels,
       };
       this.jobs_delayed.inc(jobLabels, 1);
@@ -249,7 +249,7 @@ export class BullMQMetricsFactory {
     queueEvents.on('completed', async (event) => {
       const job = await queue.getJob(event.jobId);
       const jobLabels = {
-        [LABEL_NAMES.JOB_NAME]: job.name,
+        [LABEL_NAMES.JOB_NAME]: job?.name,
         ...labels,
       };
       this.jobs_completed.inc(jobLabels, 1);


### PR DESCRIPTION
### Summary

When the volume of the queues exceeds approximately 100,000 jobs, the application encounters an issue where it cannot find the names of the jobs. This results in the application crashing.

This hotfix prevent the application from crashing for this specific reason.

### Error:

TypeError: Cannot read properties of undefined (reading 'name')
    at QueueEvents.<anonymous> (/src/bull/bullmq-metrics.factory.ts:252:37)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    error bull-monitor 7 - 2024-06-10 15:27:36 [Daemon] bull-monitor process terminated with exit code: 1 +14803ms
    
 ### Evidence
  
![image](https://github.com/ejhayes/bull-monitor/assets/91921192/5eca3ff8-59f9-4170-8790-7692e0bf30ba)
